### PR TITLE
Restructure to use cached access_token and openid user profile information.

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Here we'll add four values from old account setup as Key/Value parameters.
 |`Client_ID`|`7eph1tcmdmmYZq0znMSYn36BqMTbD6WD`|Client ID of Migration App|[Step 3](#step-3-migration-application-details)|
 |`Client_Secret`|`Y2aepoy.........6yidAyFz`|Client Secret of Migration App|[Step 3](#step-3-migration-application-details)|
 |`Audience`|`https://amin02.auth0.com/api/v2/`|Management API audience of old account|[Step 6](#step-6-management-api-audience)|
+|`Connection`|`TESTDB`|Connection name in old account||
 
 
 #### Step 15: Enable Import Users to Auth0

--- a/getUser.js
+++ b/getUser.js
@@ -1,45 +1,62 @@
 function getByEmail (email, callback) {
     // to use Auth0 search API, first we need a management API `access_token`
-    request({
-        url: 'https://' + configuration.Domain + '/oauth/token',
-        method: 'POST',
-        json: {
-            grant_type: 'client_credentials',
-            scope: 'read:users',
-            audience: configuration.Audience,
-            client_id: configuration.Client_ID,
-            client_secret: configuration.Client_Secret
-        },
-        headers: {'content-type' : 'application/json'}
-    }, function(error, response, body){
-        if(error) {
-            callback(error);
-        } else if (body.access_token) {
-            // now we have `access_token` and call invoke users `search` api
-            request({
-                url: 'https://'+ configuration.Domain + '/api/v2/users',
-                qs: {
-                    //q: '(email:"' + email + '")AND(blocked:false)'
-                    q: 'email:"' + email + '"' // query with email, using `qs` to take care of URL encoding
-                },
-                method: 'GET',
-                headers: {'content-type' : 'application/json', 'Authorization': 'Bearer ' + body.access_token}
-            }, function(error, response, body) {
-                if(error) {
-                    callback(error);
+    var moment = require('moment');
+
+    if (!global.accessToken || !global.lastLogin || moment(new Date()).diff(global.lastLogin, 'minutes') > 30) {
+        getAuth0AccessToken(email, callback);
+    } else {
+        getAuth0User(email, global.accessToken, callback);
+    }
+
+    function getAuth0AccessToken (email, cb) {
+        request({
+            url: 'https://' + configuration.Domain + '/oauth/token',
+            method: 'POST',
+            json: {
+                grant_type: 'client_credentials',
+                scope: 'read:users',
+                audience: configuration.Audience,
+                client_id: configuration.Client_ID,
+                client_secret: configuration.Client_Secret
+            },
+            headers: {'content-type' : 'application/json'}
+        }, function(error, response, body){
+            if(error) {
+                return cb(error);
+            } else if (body.access_token) {
+                // now we have `access_token` and call invoke users `search` api
+                global.accessToken = body.access_token;
+                getAuth0User (email, body.access_token, cb);
+            } else {
+                cb();
+            }
+        });    
+    }
+
+    function getAuth0User (email, accessToken, cb) {
+        request({
+            url: 'https://'+ configuration.Domain + '/api/v2/users',
+            qs: {
+                //q: '(email:"' + email + '")AND(blocked:false)'
+                q: 'email:"' + email + '" AND identities.connection:"' + configuration.Connection + '"' // query with email, using `qs` to take care of URL encoding
+            },
+            method: 'GET',
+            headers: {'content-type' : 'application/json', 'Authorization': 'Bearer ' + accessToken}
+        }, function(error, response, body) {
+            if(error) {
+                return cb(error);
+            } else {
+                var users = JSON.parse(body);
+                console.log(users);
+                // If what we get is an empty array, we know that we did not find the user in which case nothing happens
+                // otherwise we return first element of array. hopefully with email search there is only one entry
+                if(Array.isArray(users) && users.length > 0) {
+                    return cb(null, users[0]);
                 } else {
-                    var users = JSON.parse(body);
-                    // If what we get is an empty array, we know that we did not find the user in which case nothing happens
-                    // otherwise we return first element of array. hopefully with email search there is only one entry
-                    if(Array.isArray(users) && users.length > 0) {
-                        callback(null, users[0]);
-                    } else {
-                        callback();
-                    }
+                    return cb();
                 }
-            });
-        } else {
-            callback();
-        }
-    });
+            }
+        });
+    }
 }
+

--- a/getUser.js
+++ b/getUser.js
@@ -1,62 +1,27 @@
 function getByEmail (email, callback) {
     // to use Auth0 search API, first we need a management API `access_token`
-    var moment = require('moment');
-
-    if (!global.accessToken || !global.lastLogin || moment(new Date()).diff(global.lastLogin, 'minutes') > 30) {
-        getAuth0AccessToken(email, callback);
-    } else {
-        getAuth0User(email, global.accessToken, callback);
-    }
-
-    function getAuth0AccessToken (email, cb) {
-        request({
-            url: 'https://' + configuration.Domain + '/oauth/token',
-            method: 'POST',
-            json: {
-                grant_type: 'client_credentials',
-                scope: 'read:users',
-                audience: configuration.Audience,
-                client_id: configuration.Client_ID,
-                client_secret: configuration.Client_Secret
-            },
-            headers: {'content-type' : 'application/json'}
-        }, function(error, response, body){
-            if(error) {
-                return cb(error);
-            } else if (body.access_token) {
-                // now we have `access_token` and call invoke users `search` api
-                global.accessToken = body.access_token;
-                getAuth0User (email, body.access_token, cb);
-            } else {
-                cb();
-            }
-        });    
-    }
-
-    function getAuth0User (email, accessToken, cb) {
-        request({
-            url: 'https://'+ configuration.Domain + '/api/v2/users',
-            qs: {
-                //q: '(email:"' + email + '")AND(blocked:false)'
-                q: 'email:"' + email + '" AND identities.connection:"' + configuration.Connection + '"' // query with email, using `qs` to take care of URL encoding
-            },
-            method: 'GET',
-            headers: {'content-type' : 'application/json', 'Authorization': 'Bearer ' + accessToken}
-        }, function(error, response, body) {
-            if(error) {
-                return cb(error);
-            } else {
-                var users = JSON.parse(body);
-                console.log(users);
-                // If what we get is an empty array, we know that we did not find the user in which case nothing happens
-                // otherwise we return first element of array. hopefully with email search there is only one entry
-                if(Array.isArray(users) && users.length > 0) {
-                    return cb(null, users[0]);
-                } else {
-                    return cb();
-                }
-            }
-        });
-    }
+    var tools = require('auth0-extension-tools@1.3.1');
+    tools.managementApi.getClient({domain: configuration.Domain, clientId: configuration.Client_ID, clientSecret: configuration.Client_Secret})
+    .then(function(client) {
+      var params = {
+        q: 'email:"' + email + '" AND identities.connection:"' + configuration.Connection + '"'
+      };
+      client.users.getAll(params, function (err, users){
+        if (err) return callback(err);
+        else if(Array.isArray(users) && users.length > 0) {
+            var profile = {};
+            var openidProfile = users[0];
+            profile.name = openidProfile.name || '';
+            profile.nickname = openidProfile.nickname || '';
+            profile.email = openidProfile.email;
+            profile.email_verified = openidProfile.email_verified || false;
+            profile.user_id = openidProfile.user_id.replace(/^auth0/,configuration.Domain);
+            profile.user_metadata = openidProfile.user_metadata || {};
+            profile.app_metadata = openidProfile.app_metadata || {};
+            return callback(null, profile);
+        } else {
+            return callback();
+        }
+      });
+    });
 }
-

--- a/login.js
+++ b/login.js
@@ -3,8 +3,9 @@ function login (username, password, callback){
         url: 'https://' + configuration.Domain + '/oauth/token',
         method: 'POST',
         json: {
-            grant_type: 'password',
-            scope: 'openid', // todo: add name to scope
+            grant_type: "http://auth0.com/oauth/grant-type/password-realm",
+            realm : configuration.Connection,
+            scope: 'openid profile email', // todo: add name to scope
             client_id: configuration.Client_ID,
             client_secret: configuration.Client_Secret,
             username: username,
@@ -18,15 +19,20 @@ function login (username, password, callback){
             if(response.statusCode !== 200){
                 callback();
             } else {
-                var profile = jwt.decode(body.id_token); // jwt_decode
-
-                profile.user_id = profile.sub.replace(/^auth0/,configuration.Domain);
-                profile.user_metadata = profile['https://migrationapp/user_metadata'] || {};
-                profile.app_metadata = profile['https://migrationapp/app_metadata'] || {};
+                var profile = {};
+                var openidProfile = jwt.decode(body.id_token); // jwt_decode
+                profile.name = openidProfile.name || '';
+                profile.nickname = openidProfile.nickname || '';
+                profile.email = openidProfile.email;
+                profile.email_verified = openidProfile.email_verified || false;
+                profile.user_id = openidProfile.sub.replace(/^auth0/,configuration.Domain);
+                profile.user_metadata = openidProfile['https://migrationapp/user_metadata'] || {};
+                profile.app_metadata = openidProfile['https://migrationapp/app_metadata'] || {};
 
                 callback(null, profile);
             }
         }
     });
 }
+
 

--- a/metadata-rule.js
+++ b/metadata-rule.js
@@ -1,5 +1,7 @@
-function (user, context, callback) {
-    context.idToken['https://migrationapp/user_metadata'] = user.user_metadata;
-    context.idToken['https://migrationapp/app_metadata'] = user.app_metadata;
+function auth0migrateUser(user, context, callback) {
+    if (context.clientID === "{CLIENT_ID}") {
+        context.idToken['https://migrationapp/user_metadata'] = user.user_metadata || {};
+        context.idToken['https://migrationapp/app_metadata'] = user.app_metadata || {};
+      }
     callback(null, user, context);
 }


### PR DESCRIPTION
- Use built in auth0-extension-tools in getUsers script.
- Use passowrd-realm grant instead of password grant.
- Make the migration namespace claim client specific.
- Update README to include connection configuration.